### PR TITLE
Add container to the options.

### DIFF
--- a/bootstrap-iconpicker/js/bootstrap-iconpicker.js
+++ b/bootstrap-iconpicker/js/bootstrap-iconpicker.js
@@ -61,6 +61,7 @@
         labelHeader: '{0} / {1}',
         labelFooter: '{0} - {1} of {2}',
         placement: 'bottom',
+        container: 'body',
         rows: 4,
         search: true,
         searchText: 'Search icon',
@@ -332,6 +333,10 @@
         this.options.placement = value;
     };
     
+    Iconpicker.prototype.setContainer= function (value) {
+        this.options.container = value;
+    };
+    
     Iconpicker.prototype.setRows = function (value) {
         this.options.rows = value;
         this.reset();
@@ -403,7 +408,7 @@
                         trigger: 'manual',
                         html: true,
                         content: op.table,
-                        container: 'body',
+                        container: op.container,
                         placement: op.placement
                     }).on('shown.bs.popover', function () {
                         data.switchPage(op.icon);


### PR DESCRIPTION
Specify the container of the bootstrap popover can be useful in many cases. 
Example: when using Bootstrap Iconpicker in a modal, the container must be the modal itself to have the iconpicker working properly.

[09/12/2014] EDIT:
Example: 
http://jsfiddle.net/tyuy6t2s/
When the modal is opened, click on the Iconpicker button. The search input can't be modified (acting like disabled).
