### PR TITLE
Change event should be triggered after changing the input value

### DIFF
--- a/src/js/bootstrap-iconpicker.js
+++ b/src/js/bootstrap-iconpicker.js
@@ -161,8 +161,8 @@
                 el.trigger({ type: "change", icon: 'empty' });
             }
             else {
-                el.trigger({ type: "change", icon: icon });
                 el.find('input').val(icon);
+                el.trigger({ type: "change", icon: icon });
             }
             op.table.find('button.' + op.selectedClass).removeClass(op.selectedClass);
         }


### PR DESCRIPTION
In my case I wanted to change that value after change, and it's not possible since the value is after that changed by the plugin.
This sequence makes more sense I think.